### PR TITLE
bump fleet-protocol-interface to v2.1.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,3 +1,3 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
-BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.1.0 NO_DEBUG ON)


### PR DESCRIPTION
`fleet-protocol-interface v2.0.0` was removed from the gitea package repository; only `v2.1.0` remains. This also conflicts with module-gateway (which now pins v2.1.0): CMLIB reports `cache under keywords 'BACPACK;FLEETPROTOCOLINTERFACE' already exist for different remote` during configure. Bumping to match.